### PR TITLE
Use fresh react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "browser": "src/init.client.js",
   "main": "src/init.server.js",
   "optionalDependencies": {
-    "react-hot-loader": "0.4.5",
+    "react-hot-loader": "1.0.6",
     "webpack-dev-server": "1.6.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
I suggest you use 1.x from now on. There's been breaking changes but they [don't seem to touch you](https://github.com/gaearon/react-hot-loader/tree/master/docs#migrating-to-10). 1.x is future proof and will work with React 0.13 and ES6 classes.
