### PR TITLE
fixed bug: "Ambidex could not find <BASE><BASE>"

### DIFF
--- a/src/Ambidex.server.js
+++ b/src/Ambidex.server.js
@@ -136,7 +136,7 @@ Ambidex.prototype._verifyPaths = function () {
   var basePath  = paths["BASE"];
 
   return Promise.all(
-    Lazy(paths).omit("BASE").map(
+    Lazy(paths).omit(["BASE"]).map(
       (path, name) => {
         path = path.startsWith("/")
           ? path


### PR DESCRIPTION
`Lazy(paths).omit("BASE")`
should be
`Lazy(paths).omit(["BASE"])`

this caused the https://github.com/appsforartists/ambidex-example--bike-index to fail on startup

see http://danieltao.com/lazy.js/docs/#ObjectLikeSequence-omit
