### PR TITLE
Fix typo in UglifyJS options

### DIFF
--- a/src/createWebpackSettings.js
+++ b/src/createWebpackSettings.js
@@ -120,7 +120,7 @@ function getSettings (options) {
       new Webpack.optimize.UglifyJsPlugin(
         {
           "output":   {
-                        "inline_scripts":   true
+                        "inline_script":   true
                       }
         }
       )


### PR DESCRIPTION
This typo caused UglifyJS to print an unhelpful error in some configurations.

Example of the error output:

ERROR in jsx.js from UglifyJs
undefined

ERROR in styles.js from UglifyJs
undefined

To reproduce the problem set ENABLE_HOT_MODULE_REPLACEMENT to false in the example project.
