### PR TITLE
[fixed] assertion of object argument in connectStoresToLocalState

### DIFF
--- a/src/mixinCreators/connectStoresToLocalState.jsx
+++ b/src/mixinCreators/connectStoresToLocalState.jsx
@@ -22,7 +22,7 @@ var connectStoresToLocalState = function (listenableNames) {
      *    )
      */
 
-  console.assert(listenableNames.length, "connectStoresToLocalState needs to know which stores to connect.");
+  console.assert(arguments.length > 0, "connectStoresToLocalState needs to know which stores to connect.");
 
   if (arguments.length == 2) {
     listenableNames = Lazy([arguments]).toObject();


### PR DESCRIPTION
The assertion failed for object arguments since they don't have a length property.

E.g. the assertion would trigger for this (valid) argument:

``` javascript
var BikeDetails = React.createClass(
  {
    "mixins":                     [
                                    Ambidex.mixinCreators.connectStoresToLocalState(
                                      {"CurrentBike": "currentBike"}
                                    ),
                                    ...
```

(I know that it would be sufficient to say `console.assert(arguments.length, "...")`, but I like to have my code explicit and not to rely on the coercion )
